### PR TITLE
Insert an optional field for idnumber (studentid) to SAML auth method

### DIFF
--- a/htdocs/auth/saml/lang/en.utf8/auth.saml.php
+++ b/htdocs/auth/saml/lang/en.utf8/auth.saml.php
@@ -60,6 +60,7 @@ $string['resetmetadata'] = 'Reset the certificates for Mahara\'s metadata. This 
 $string['samlfieldforemail'] = 'SSO field for email';
 $string['samlfieldforfirstname'] = 'SSO field for first name';
 $string['samlfieldforsurname'] = 'SSO field for surname';
+$string['samlfieldforstudentid'] = 'SSO field for studentid';
 $string['spentityid'] = "Service Provider entityId";
 $string['title'] = 'SAML';
 $string['updateuserinfoonlogin'] = 'Update user details on login';

--- a/htdocs/auth/saml/lib.php
+++ b/htdocs/auth/saml/lib.php
@@ -90,6 +90,7 @@ class AuthSaml extends Auth {
         $firstname       = isset($attributes[$this->config['firstnamefield']][0]) ? $attributes[$this->config['firstnamefield']][0] : null;
         $lastname        = isset($attributes[$this->config['surnamefield']][0]) ? $attributes[$this->config['surnamefield']][0] : null;
         $email           = isset($attributes[$this->config['emailfield']][0]) ? $attributes[$this->config['emailfield']][0] : null;
+        $studentid           = isset($attributes[$this->config['studentidfield']][0]) ? $attributes[$this->config['studentidfield']][0] : null;
         $institutionname = $this->institution;
 
         $create = false;
@@ -183,6 +184,7 @@ class AuthSaml extends Auth {
             $user->firstname          = $firstname;
             $user->lastname           = $lastname;
             $user->email              = $email;
+            $user->studentid          = $studentid;
 
             // must have these values
             if (empty($firstname) || empty($lastname) || empty($email)) {
@@ -229,6 +231,14 @@ class AuthSaml extends Auth {
                 set_profile_field($user->id, 'email', $email);
                 $user->email = $email;
             }
+
+
+            if (! empty($studentid)) {
+                set_profile_field($user->id, 'studentid', $studentid);
+                $user->studentid = $studentid;
+            }
+
+
             $user->lastlastlogin      = $user->lastlogin;
             $user->lastlogin          = time();
         }

--- a/htdocs/auth/saml/lib.php
+++ b/htdocs/auth/saml/lib.php
@@ -280,6 +280,7 @@ class PluginAuthSaml extends PluginAuth {
         'firstnamefield'        => '',
         'surnamefield'          => '',
         'emailfield'            => '',
+        'studentidfield'         => '',
         'updateuserinfoonlogin' => 1,
         'institution'           => '',
         'institutionattribute'  => '',
@@ -557,107 +558,113 @@ class PluginAuthSaml extends PluginAuth {
             $idp_title .= " (" . $entityid . ")";
         }
         $elements = array(
-            'instance' => array(
-                'type'  => 'hidden',
-                'value' => $instance,
+          'instance' => array(
+            'type' => 'hidden',
+            'value' => $instance,
+          ),
+          'instancename' => array(
+            'type' => 'hidden',
+            'value' => 'SAML',
+          ),
+          'institution' => array(
+            'type' => 'hidden',
+            'value' => $institution,
+          ),
+          'authname' => array(
+            'type' => 'hidden',
+            'value' => 'saml',
+          ),
+          'institutionidp' => array(
+            'type' => 'textarea',
+            'title' => $idp_title,
+            'rows' => 10,
+            'cols' => 80,
+            'defaultvalue' => self::$default_config['institutionidp'],
+            'help' => true,
+            'class' => 'under-label',
+          ),
+          'institutionattribute' => array(
+            'type' => 'text',
+            'title' => get_string('institutionattribute', 'auth.saml', $institution),
+            'rules' => array(
+              'required' => true,
             ),
-            'instancename' => array(
-                'type'  => 'hidden',
-                'value' => 'SAML',
+            'defaultvalue' => self::$default_config['institutionattribute'],
+            'help' => true,
+          ),
+          'institutionvalue' => array(
+            'type' => 'text',
+            'title' => get_string('institutionvalue', 'auth.saml'),
+            'rules' => array(
+              'required' => true,
             ),
-            'institution' => array(
-                'type'  => 'hidden',
-                'value' => $institution,
+            'defaultvalue' => self::$default_config['institutionvalue'],
+            'help' => true,
+          ),
+          'institutionregex' => array(
+            'type' => 'switchbox',
+            'title' => get_string('institutionregex', 'auth.saml'),
+            'defaultvalue' => self::$default_config['institutionregex'],
+            'help' => true,
+          ),
+          'user_attribute' => array(
+            'type' => 'text',
+            'title' => get_string('userattribute', 'auth.saml'),
+            'rules' => array(
+              'required' => true,
             ),
-            'authname' => array(
-                'type'  => 'hidden',
-                'value' => 'saml',
-            ),
-            'institutionidp' => array(
-                'type'  => 'textarea',
-                'title' => $idp_title,
-                'rows' => 10,
-                'cols' => 80,
-                'defaultvalue' => self::$default_config['institutionidp'],
-                'help' => true,
-                'class' => 'under-label',
-            ),
-            'institutionattribute' => array(
-                'type'  => 'text',
-                'title' => get_string('institutionattribute', 'auth.saml', $institution),
-                'rules' => array(
-                    'required' => true,
-                ),
-                'defaultvalue' => self::$default_config['institutionattribute'],
-                'help' => true,
-            ),
-            'institutionvalue' => array(
-                'type'  => 'text',
-                'title' => get_string('institutionvalue', 'auth.saml'),
-                'rules' => array(
-                'required' => true,
-                ),
-                'defaultvalue' => self::$default_config['institutionvalue'],
-                'help' => true,
-            ),
-            'institutionregex' => array(
-                'type'         => 'switchbox',
-                'title' => get_string('institutionregex', 'auth.saml'),
-                'defaultvalue' => self::$default_config['institutionregex'],
-                'help' => true,
-            ),
-            'user_attribute' => array(
-                'type'  => 'text',
-                'title' => get_string('userattribute', 'auth.saml'),
-                'rules' => array(
-                    'required' => true,
-                ),
-                'defaultvalue' => self::$default_config['user_attribute'],
-                'help' => true,
-            ),
-            'remoteuser' => array(
-                'type'         => 'switchbox',
-                'title' => get_string('remoteuser', 'auth.saml'),
-                'defaultvalue' => self::$default_config['remoteuser'],
-                'help'  => true,
-            ),
-            'loginlink' => array(
-                'type'         => 'switchbox',
-                'title' => get_string('loginlink', 'auth.saml'),
-                'defaultvalue' => self::$default_config['loginlink'],
-                'disabled' => (self::$default_config['remoteuser'] ? false : true),
-                'help'  => true,
-            ),
-            'updateuserinfoonlogin' => array(
-                'type'         => 'switchbox',
-                'title' => get_string('updateuserinfoonlogin', 'auth.saml'),
-                'defaultvalue' => self::$default_config['updateuserinfoonlogin'],
-                'help'  => true,
-            ),
-            'weautocreateusers' => array(
-                'type'         => 'switchbox',
-                'title' => get_string('weautocreateusers', 'auth.saml'),
-                'defaultvalue' => self::$default_config['weautocreateusers'],
-                'help'  => true,
-            ),
-            'firstnamefield' => array(
-                'type'  => 'text',
-                'title' => get_string('samlfieldforfirstname', 'auth.saml'),
-                'defaultvalue' => self::$default_config['firstnamefield'],
-                'help'  => true,
-            ),
-            'surnamefield' => array(
-                'type'  => 'text',
-                'title' => get_string('samlfieldforsurname', 'auth.saml'),
-                'defaultvalue' => self::$default_config['surnamefield'],
-                'help'  => true,
-            ),
-            'emailfield' => array(
-                'type'  => 'text',
-                'title' => get_string('samlfieldforemail', 'auth.saml'),
-                'defaultvalue' => self::$default_config['emailfield'],
-                'help' => true,
-            ),
+            'defaultvalue' => self::$default_config['user_attribute'],
+            'help' => true,
+          ),
+          'remoteuser' => array(
+            'type' => 'switchbox',
+            'title' => get_string('remoteuser', 'auth.saml'),
+            'defaultvalue' => self::$default_config['remoteuser'],
+            'help' => true,
+          ),
+          'loginlink' => array(
+            'type' => 'switchbox',
+            'title' => get_string('loginlink', 'auth.saml'),
+            'defaultvalue' => self::$default_config['loginlink'],
+            'disabled' => (self::$default_config['remoteuser'] ? false : true),
+            'help' => true,
+          ),
+          'updateuserinfoonlogin' => array(
+            'type' => 'switchbox',
+            'title' => get_string('updateuserinfoonlogin', 'auth.saml'),
+            'defaultvalue' => self::$default_config['updateuserinfoonlogin'],
+            'help' => true,
+          ),
+          'weautocreateusers' => array(
+            'type' => 'switchbox',
+            'title' => get_string('weautocreateusers', 'auth.saml'),
+            'defaultvalue' => self::$default_config['weautocreateusers'],
+            'help' => true,
+          ),
+          'firstnamefield' => array(
+            'type' => 'text',
+            'title' => get_string('samlfieldforfirstname', 'auth.saml'),
+            'defaultvalue' => self::$default_config['firstnamefield'],
+            'help' => true,
+          ),
+          'surnamefield' => array(
+            'type' => 'text',
+            'title' => get_string('samlfieldforsurname', 'auth.saml'),
+            'defaultvalue' => self::$default_config['surnamefield'],
+            'help' => true,
+          ),
+          'emailfield' => array(
+            'type' => 'text',
+            'title' => get_string('samlfieldforemail', 'auth.saml'),
+            'defaultvalue' => self::$default_config['emailfield'],
+            'help' => true,
+          ),
+          'studentidfield' => array(
+            'type' => 'text',
+            'title' => 'Test id number',
+            'defaultvalue' => self::$default_config['studentidfield'],
+            'help' => true,
+          ),
         );
 
         return array(
@@ -802,6 +809,7 @@ class PluginAuthSaml extends PluginAuth {
             'firstnamefield' => $values['firstnamefield'],
             'surnamefield' => $values['surnamefield'],
             'emailfield' => $values['emailfield'],
+            'studentidfield' => $values['studentidfield'],
             'updateuserinfoonlogin' => $values['updateuserinfoonlogin'],
             'institutionattribute' => $values['institutionattribute'],
             'institutionvalue' => $values['institutionvalue'],

--- a/htdocs/auth/saml/lib.php
+++ b/htdocs/auth/saml/lib.php
@@ -671,7 +671,7 @@ class PluginAuthSaml extends PluginAuth {
           ),
           'studentidfield' => array(
             'type' => 'text',
-            'title' => 'Test id number',
+            'title' => get_string('samlfieldforstudentid', 'auth.saml'),
             'defaultvalue' => self::$default_config['studentidfield'],
             'help' => true,
           ),


### PR DESCRIPTION
We need it for our work and we thought that could be interesting to everybody.
We have just included it into the branch 16.10_STABLE (because it is the one we are working on) but we can add the changes in master if it could help the integrator.

