### PR TITLE
Fix for displaying external videos in iframes

### DIFF
--- a/htdocs/theme/raw/plugintype/blocktype/externalvideo/templates/content.tpl
+++ b/htdocs/theme/raw/plugintype/blocktype/externalvideo/templates/content.tpl
@@ -36,7 +36,7 @@
                 blockinstance_{$blockid}_loaded = true;
                 $j('#user_block_{$blockid}_waiting').css('display','none');
                 {else}
-                $j('<iframe />').attr('src', '{$jsurl}')
+                $j('<iframe />').attr('src', '{$jsurl|safe}')
                                 .attr('width', '{$width}')
                                 .attr('height', '{$height}')
                                 .attr('frameborder', '0')


### PR DESCRIPTION
I'm not sure how you accept contrib/fixes so may have missed out some process here...
My client was embedding a video using the external video block. The iframe they were providing had query string parameters in its source url, these were being encoded as html entities which broke the URL.