### PR TITLE
bug #1841571

### DIFF
--- a/htdocs/search/internal/lib.php
+++ b/htdocs/search/internal/lib.php
@@ -275,7 +275,10 @@ class PluginSearchInternal extends PluginSearch {
             $valuecount += $matchcount;
         }
 
-        $querydata = self::split_query_string(strtolower(trim($query_string)));
+        // $querydata = self::split_query_string(strtolower(trim($query_string)));
+        // Bug #1841571 get usersearch working with Multibyte-Characters on a Solaris OS
+        $querydata = self::split_query_string(mb_strtolower(trim($query_string)));
+
         $hidenameallowed = get_config('userscanhiderealnames') ? 'TRUE' : 'FALSE';
         $searchusernamesallowed = $USER->get('admin') || $USER->get('staff') || !get_config('nousernames') ? 'TRUE' : 'FALSE';
 
@@ -514,7 +517,9 @@ class PluginSearchInternal extends PluginSearch {
         $ilike = db_ilike();
 
         // Generate the part that matches the search term
-        $querydata = self::split_query_string(strtolower(trim($query_string)));
+        //$querydata = self::split_query_string(strtolower(trim($query_string)));
+        // Bug #1841571 get usersearch working with Multibyte-Characters on a Solaris OS
+        $querydata = self::split_query_string(mb_strtolower(trim($query_string)));
 
         $matches = array();
         $valuecount = 0;
@@ -1046,8 +1051,9 @@ class PluginSearchInternal extends PluginSearch {
                 (LOWER(at.tag) = ?)
             )";
         array_unshift($querydata[1], $USER->get('id'));
-        array_push($querydata[1], strtolower($querystring));
-
+        //array_push($querydata[1], strtolower($querystring));
+        // Bug #1841571 get usersearch working with Multibyte-Characters on a Solaris OS
+        array_push($querydata[1], mb_strtolower($querystring));
         $results = array(
             'data'   => get_records_sql_array($sql, $querydata[1], $offset, $limit),
             'offset' => $offset,
@@ -1576,7 +1582,9 @@ class PluginSearchInternal extends PluginSearch {
       $text = self::decode_entities($text);
 
       // Lowercase
-      $text = strtolower($text);
+      //$text = strtolower($text);
+      // Bug #1841571 get usersearch working with Multibyte-Characters on a Solaris OS
+      $text = mb_strtolower($text);
 
       // Call an external processor for word handling.
       //search_preprocess($text);


### PR DESCRIPTION
replaced strtolower()-function by mb_strtolower() to get the usersearch working with multibyte-characters on Solaris OS