### PR TITLE
Add support for MySQL 8 in lib/gridstacklayout

### DIFF
--- a/htdocs/lib/gridstacklayout.php
+++ b/htdocs/lib/gridstacklayout.php
@@ -119,16 +119,17 @@ function get_column_widths($viewid, $row) {
 function get_blocks_in_old_layout($viewid) {
 
     // get old layout structure
-    $sql = "SELECT row, columns
+    $sql = "SELECT \"row\", columns
         FROM {view_rows_columns}
-        WHERE view = ? ORDER BY row";
+        WHERE view = ?
+        ORDER BY \"row\"";
     $oldlayout = get_records_sql_array($sql, array($viewid));
 
     // get blocks in old layout
-    $sql = "SELECT id, row, " . db_quote_identifier('column') . ", " . db_quote_identifier('order') . "
+    $sql = "SELECT id, \"row\", " . db_quote_identifier('column') . ", " . db_quote_identifier('order') . "
         FROM {block_instance}
         WHERE view = ?
-        ORDER BY row, " . db_quote_identifier('column') . ", " . db_quote_identifier('order');
+        ORDER BY \"row\", " . db_quote_identifier('column') . ", " . db_quote_identifier('order');
     $oldblocks = get_records_sql_array($sql, array($viewid));
     if ($oldlayout) {
         foreach ($oldlayout as $row) {


### PR DESCRIPTION
As far as I see the fix in
https://bugs.launchpad.net/mahara/+bug/1845228
didn't cover the reserved word `row` newly introduced with MySQL 8.
See https://dev.mysql.com/doc/refman/8.0/en/keywords.html

This change quotes all protected words used in lib/gridstacklayout.