### PR TITLE
XMLRPC decode fix

### DIFF
--- a/htdocs/api/xmlrpc/client.php
+++ b/htdocs/api/xmlrpc/client.php
@@ -110,7 +110,8 @@ class Client {
         }
 
         if ($xml->getName() == 'methodResponse') {
-            $this->response = xmlrpc_decode($payload);
+            // Decode with UTF-8 as that is the encoding we request.
+            $this->response = xmlrpc_decode($payload, 'utf-8');
 
             // Margin of error is the time it took the request to complete.
             $margin_of_error  = $timestamp_receive - $timestamp_send;


### PR DESCRIPTION
We request the data with the UTF-8 encoding, but use the default iso-8859-1 for the decoding which breaks on characters such as "ö"